### PR TITLE
BOL patterns matching

### DIFF
--- a/src/klex/Compiler.h
+++ b/src/klex/Compiler.h
@@ -31,8 +31,9 @@ class Compiler {
  public:
   using TagNameMap = std::map<Tag, std::string>;
   using OvershadowMap = DFABuilder::OvershadowMap;
+  using AutomataMap = std::map<std::string, NFA>;
 
-  Compiler() : fa_{} {}
+  Compiler() : rules_{}, containsBeginOfLine_{false}, fa_{}, names_{} {}
 
   /**
    * Parses a @p stream of textual rule definitions to construct their internal data structures.
@@ -43,11 +44,6 @@ class Compiler {
    * Parses a list of @p rules to construct their internal data structures.
    */
   void declareAll(RuleList rules);
-
-  /**
-   * Parses a single @p rule to construct their internal data structures.
-   */
-  void declare(Rule rule);
 
   const RuleList& rules() const noexcept { return rules_; }
   const TagNameMap& names() const noexcept { return names_; }
@@ -72,18 +68,33 @@ class Compiler {
   LexerDef compile();
 
   /**
+   * Compiles all previousely parsed rules into a suitable data structure for Lexer, taking care of
+   * multiple conditions as well as begin-of-line.
+   */
+  LexerDef compileMulti();
+
+  /**
    * Translates the given DFA @p dfa with a given TagNameMap @p names into trivial table mappings.
    *
    * @see Lexer
    */
-  static LexerDef generateTables(const DFA& dfa, const TagNameMap& names);
-  static LexerDef generateTables(const MultiDFA& dfa, const TagNameMap& names);
+  static LexerDef generateTables(const DFA& dfa, bool requiresBeginOfLine, const TagNameMap& names);
+  static LexerDef generateTables(const MultiDFA& dfa, bool requiresBeginOfLine, const TagNameMap& names);
 
   const std::map<std::string, NFA>& automata() const { return fa_; }
 
+  bool containsBeginOfLine() const noexcept { return containsBeginOfLine_; }
+
+ private:
+  /**
+   * Parses a single @p rule to construct their internal data structures.
+   */
+  void declare(const Rule& rule, const std::string& conditionSuffix = "");
+
  private:
   RuleList rules_;
-  std::map<std::string, NFA> fa_;
+  bool containsBeginOfLine_;
+  AutomataMap fa_;
   TagNameMap names_;
 };
 

--- a/src/klex/DFA.cc
+++ b/src/klex/DFA.cc
@@ -52,7 +52,10 @@ void DFA::setInitialState(StateId s) {
 
 void DFA::setTransition(StateId from, Symbol symbol, StateId to) {
   const State& s = states_[from];
-  assert(s.transitions.find(symbol) == s.transitions.end());
+  if (auto i = s.transitions.find(symbol); i != s.transitions.end()) {
+    printf("overwriting transition! %lu --(%s)--> %lu (new: %lu)\n", from, prettySymbol(symbol).c_str(), i->second, to);
+  }
+  // XXX assert(s.transitions.find(symbol) == s.transitions.end());
   states_[from].transitions[symbol] = to;
 }
 

--- a/src/klex/DFAMinimizer.h
+++ b/src/klex/DFAMinimizer.h
@@ -35,6 +35,7 @@ class DFAMinimizer {
   void constructPartitions();
   StateIdVec nonAcceptStates() const;
   bool containsInitialState(const StateIdVec& S) const;
+  bool isMultiInitialState(StateId s) const;
   PartitionVec::iterator findGroup(StateId s);
   int partitionId(StateId s) const;
   PartitionVec split(const StateIdVec& S) const;

--- a/src/klex/Lexer.h
+++ b/src/klex/Lexer.h
@@ -24,7 +24,10 @@ namespace klex {
 /**
  * Lexer API for recognizing words.
  */
-template<typename Token = Tag, typename Machine = StateId, const bool Debug = false>
+template<typename Token = Tag,
+         typename Machine = StateId,
+         const bool RequiresBeginOfLine = true,
+         const bool Debug = false>
 class Lexer {
  private:
   using DebugLogger = std::function<void(const std::string&)>;
@@ -140,10 +143,13 @@ class Lexer {
  private:
   Symbol nextChar();
   void rollback();
+  StateId getInitialState() const noexcept;
   bool isAcceptState(StateId state) const;
   static std::string stateName(StateId s, const std::string_view& n = "n");
   static constexpr StateId BadState = 101010;
   std::string toString(const std::deque<StateId>& stack);
+
+  int currentChar() const noexcept { return currentChar_; }
 
   Token token(StateId s) const {
     auto i = acceptStates_.find(s);
@@ -154,6 +160,7 @@ class Lexer {
  private:
   const TransitionMap transitions_;
   const std::map<std::string, StateId> initialStates_;
+  const bool containsBeginOfLineStates_;
   const std::map<StateId, Tag> acceptStates_;
   const BacktrackingMap backtracking_;
   const std::map<Tag, std::string> tagNames_;
@@ -167,6 +174,8 @@ class Lexer {
   unsigned offset_;
   unsigned line_;
   unsigned column_;
+  bool isBeginOfLine_;
+  int currentChar_;
   Token token_;
 };
 

--- a/src/klex/LexerDef.h
+++ b/src/klex/LexerDef.h
@@ -25,6 +25,7 @@ using BacktrackingMap = std::map<StateId, StateId>;
 
 struct LexerDef {
   std::map<std::string, StateId> initialStates;
+  bool containsBeginOfLineStates;
   TransitionMap transitions;
   AcceptStateMap acceptStates;
   BacktrackingMap backtrackingStates;

--- a/src/klex/NFABuilder.cc
+++ b/src/klex/NFABuilder.cc
@@ -78,7 +78,7 @@ void NFABuilder::visit(ClosureExpr& closureExpr) {
 }
 
 void NFABuilder::visit(BeginOfLineExpr& bolExpr) {
-  fa_ = NFA{Symbols::BeginOfLine}; // TODO
+  fa_ = NFA{Symbols::Epsilon};
 }
 
 void NFABuilder::visit(EndOfLineExpr& eolExpr) {

--- a/src/klex/RegExpr.cc
+++ b/src/klex/RegExpr.cc
@@ -179,4 +179,42 @@ std::string EmptyExpr::to_string() const {
   return {};
 }
 
+// {{{ BeginOfLineTester
+class BeginOfLineTester : public RegExprVisitor {
+ public:
+  bool test(const RegExpr* re) {
+    const_cast<RegExpr*>(re)->accept(*this);
+    return result_;
+  }
+
+ private:
+  void set(bool r) {
+    result_ = r;
+  }
+
+  void visit(LookAheadExpr& lookaheadExpr) override {
+    test(lookaheadExpr.leftExpr());
+  }
+
+  void visit(ConcatenationExpr& concatenationExpr) override {
+    set(test(concatenationExpr.leftExpr()) || test(concatenationExpr.rightExpr()));
+  }
+
+  void visit(AlternationExpr& alternationExpr) override {
+    set(test(alternationExpr.leftExpr()) || test(alternationExpr.rightExpr()));
+  }
+
+  void visit(BeginOfLineExpr& bolExpr) override {
+    set(true);
+  }
+
+ private:
+  bool result_ = false;
+};
+
+bool containsBeginOfLine(const RegExpr* re) {
+  return BeginOfLineTester{}.test(re);
+}
+// }}}
+
 } // namespace klex

--- a/src/klex/RegExpr.cc
+++ b/src/klex/RegExpr.cc
@@ -81,20 +81,11 @@ void LookAheadExpr::accept(RegExprVisitor& visitor) {
 }
 
 std::string LookAheadExpr::to_string() const {
+  assert(precedence() < left_->precedence());
+  assert(precedence() < right_->precedence());
+
   std::stringstream sstr;
-
-  if (precedence() > left_->precedence()) {
-    sstr << '(' << left_->to_string() << ')';
-  } else
-    sstr << left_->to_string();
-
-  sstr << "/";
-
-  if (precedence() > right_->precedence()) {
-    sstr << '(' << right_->to_string() << ')';
-  } else
-    sstr << right_->to_string();
-
+  sstr << left_->to_string() << '/' << right_->to_string();
   return sstr.str();
 }
 

--- a/src/klex/RegExpr.h
+++ b/src/klex/RegExpr.h
@@ -198,17 +198,19 @@ class RegExprVisitor {
  public:
   virtual ~RegExprVisitor() {}
 
-  virtual void visit(LookAheadExpr& lookaheadExpr) = 0;
-  virtual void visit(ConcatenationExpr& concatenationExpr) = 0;
-  virtual void visit(AlternationExpr& alternationExpr) = 0;
-  virtual void visit(CharacterExpr& characterExpr) = 0;
-  virtual void visit(CharacterClassExpr& characterClassExpr) = 0;
-  virtual void visit(ClosureExpr& closureExpr) = 0;
-  virtual void visit(BeginOfLineExpr& eolExpr) = 0;
-  virtual void visit(EndOfLineExpr& eolExpr) = 0;
-  virtual void visit(EndOfFileExpr& eofExpr) = 0;
-  virtual void visit(DotExpr& dotExpr) = 0;
-  virtual void visit(EmptyExpr& emptyExpr) = 0;
+  virtual void visit(LookAheadExpr& lookaheadExpr) {}
+  virtual void visit(ConcatenationExpr& concatenationExpr) {}
+  virtual void visit(AlternationExpr& alternationExpr) {}
+  virtual void visit(CharacterExpr& characterExpr) {}
+  virtual void visit(CharacterClassExpr& characterClassExpr) {}
+  virtual void visit(ClosureExpr& closureExpr) {}
+  virtual void visit(BeginOfLineExpr& eolExpr) {}
+  virtual void visit(EndOfLineExpr& eolExpr) {}
+  virtual void visit(EndOfFileExpr& eofExpr) {}
+  virtual void visit(DotExpr& dotExpr) {}
+  virtual void visit(EmptyExpr& emptyExpr) {}
 };
+
+bool containsBeginOfLine(const RegExpr* re);
 
 } // namespace klex

--- a/src/klex/RegExprParser_test.cc
+++ b/src/klex/RegExprParser_test.cc
@@ -261,6 +261,11 @@ TEST(RegExprParser, closure_range) {
   EXPECT_EQ("a{2,4}", re->to_string());
 }
 
+TEST(RegExprParser, empty) {
+  auto re = RegExprParser{}.parse("(a|)");
+  EXPECT_EQ("a|", re->to_string()); // grouping '(' & ')' is not preserved as node in the parse tree.
+}
+
 TEST(RegExprParser, UnexpectedToken_grouping) {
   EXPECT_THROW(RegExprParser{}.parse("(a"), RegExprParser::UnexpectedToken);
 }

--- a/src/klex/RuleParser.cc
+++ b/src/klex/RuleParser.cc
@@ -101,6 +101,11 @@ void RuleParser::parseRule(RuleList& rules) {
   }
 }
 
+struct TestRuleForName {
+  std::string name;
+  bool operator()(const Rule& r) const { return r.name == name; }
+};
+
 void RuleParser::parseBasicRule(RuleList& rules, std::vector<std::string>&& conditions) {
   const unsigned int beginLine = line_;
   const unsigned int beginColumn = column_;
@@ -132,8 +137,7 @@ void RuleParser::parseBasicRule(RuleList& rules, std::vector<std::string>&& cond
   const Tag tag = [&] {
     if (ignore || ref)
       return IgnoreTag;
-    else if (auto i = std::find_if(rules.begin(), rules.end(),
-                                   [&](const auto& r) { return r.name == token; }); i != rules.end())
+    else if (auto i = std::find_if(rules.begin(), rules.end(), TestRuleForName{token}); i != rules.end())
       return i->tag;
     else
       return nextTag_++;
@@ -149,8 +153,7 @@ void RuleParser::parseBasicRule(RuleList& rules, std::vector<std::string>&& cond
   std::sort(conditions.begin(), conditions.end());
 
   if (!ref) {
-    if (auto i = std::find_if(rules.begin(), rules.end(),
-                              [&](const Rule& r) { return r.name == token; }); i != rules.end()) {
+    if (auto i = std::find_if(rules.begin(), rules.end(), TestRuleForName{token}); i != rules.end()) {
       throw DuplicateRule{Rule{line, column, tag, std::move(conditions), token, pattern}, *i};
     } else {
       rules.emplace_back(Rule{line, column, tag, conditions, token, pattern});

--- a/src/klex/RuleParser.h
+++ b/src/klex/RuleParser.h
@@ -29,7 +29,6 @@ class RuleParser {
   class InvalidRuleOption;
   class InvalidRefRuleWithConditions;
   class DuplicateRule;
-  class MismatchingConditions;
 
  private:
   void parseRule(RuleList& rules);
@@ -66,7 +65,7 @@ class RuleParser::InvalidRefRuleWithConditions : public std::runtime_error {
   InvalidRefRuleWithConditions(unsigned line, unsigned column, Rule rule)
       : std::runtime_error{fmt::format("{}:{}: Invalid rule \"{}\". Reference rules must not be labelled with conditions.",
           line, column, rule.name)},
-      rule_{rule} {}
+      rule_{std::move(rule)} {}
 
   const Rule& rule() const noexcept { return rule_; }
 
@@ -148,23 +147,6 @@ class RuleParser::InvalidRuleOption : public std::runtime_error {
  private:
   unsigned offset_;
   std::string option_;
-};
-
-class RuleParser::MismatchingConditions : public std::runtime_error {
- public:
-  MismatchingConditions(const Rule& first, const Rule& second)
-      : std::runtime_error{fmt::format("[{}:{}] Mismatching conditions in rule \"{}\" with alternating rule at {}:{}.",
-          second.line, second.column, second.name, first.line, first.column)},
-        first_{first},
-        second_{second}
-  {}
-
-  const Rule& first() const noexcept { return first_; }
-  const Rule& second() const noexcept { return second_; }
-
- private:
-  const Rule first_;
-  const Rule second_;
 };
 
 } // namespace klex

--- a/src/mklex.cc
+++ b/src/mklex.cc
@@ -98,6 +98,8 @@ void generateTableDefCxx(std::ostream& os, const klex::LexerDef& lexerDef, const
   for (const std::pair<const std::string, klex::StateId>& s0 : lexerDef.initialStates)
     os << fmt::format("    {{ \"{}\", {} }},\n", s0.first, s0.second);
   os << "  },\n";
+  os << "  // containsBeginOfLineStates\n";
+  os << "  " << (lexerDef.containsBeginOfLineStates ? "true" : "false") << ",\n";
   os << "  // state transition table \n";
   os << "  klex::TransitionMap::Container {\n";
   for (klex::StateId stateId : lexerDef.transitions.states()) {
@@ -274,7 +276,7 @@ int main(int argc, const char* argv[]) {
     }
   }
 
-  klex::LexerDef lexerDef = klex::Compiler::generateTables(multiDFA, builder.names());
+  klex::LexerDef lexerDef = klex::Compiler::generateTables(multiDFA, builder.containsBeginOfLine(), builder.names());
   if (std::string tableFile = flags.getString("output-table"); tableFile != "-") {
     if (auto p = fs::path{tableFile}.remove_filename(); p != "")
       fs::create_directories(p);


### PR DESCRIPTION
*WORK-IN-PROGRESS*

Closes #10

Implements BOL pattern matching in regular expressions.

### Checklist

- [x] DFA/MinDFA compilation must not take longer when no begin-of-line conditions are required.
- [x] think about an API to split between a `Lexer` that can deal with BOL and one that cannot (to improve speed on non-BOL-grammars)
- [x] Have a test for ensuring a BOL'd LexerDef is not accepted as input of a `Lexer` that doesn't support BOL.
